### PR TITLE
Add remote stop playback support

### DIFF
--- a/ESP32/main.py
+++ b/ESP32/main.py
@@ -238,6 +238,17 @@ def start_server(port=80):
                 except Exception as exc:
                     send_error(conn, 409, "Conflict", "Kon playback niet starten: {}".format(exc))
                 continue
+            if path == "/stop_playback" and method == "GET":
+                music_player.interupt_playback()
+                try:
+                    send_response(
+                        conn,
+                        json.dumps({"stopped": True}),
+                        content_type="application/json; charset=utf-8",
+                    )
+                except Exception as exc:
+                    log("Fout bij stoppen response: {}".format(exc))
+                continue
 
             name = params.get("name", "")
             file_id = params.get("id", "")

--- a/ESP32/music_player.py
+++ b/ESP32/music_player.py
@@ -180,6 +180,8 @@ def play_file(path, delete_after=False):
             for line in f:
                 if stop_playback:
                     stop_playback = False
+                    if delete_after:
+                        _delete_file(path)
                     log('playback onderbroken')
                     return
                 if music_len is None and "int musicLen" in line:

--- a/ESP32/music_player.py
+++ b/ESP32/music_player.py
@@ -16,6 +16,7 @@ SIMULATION_LOG_WAITS = False
 
 _current_txt_path = None
 _is_playing = False
+stop_playback = False
 
 _ROW_PATTERN = re.compile(r"\{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}")
 _LEN_PATTERN = re.compile(r"int\s+musicLen\s*=\s*(\d+)")
@@ -161,7 +162,7 @@ def stop_all(outputs=None):
 
 
 def play_file(path, delete_after=False):
-    global _is_playing, _current_txt_path
+    global _is_playing, _current_txt_path, stop_playback
 
     log("Muziek laden: {}".format(path))
     log("Mode: {}".format("STEPPER" if STEPPER_ENABLED else "SIMULATIE"))
@@ -177,6 +178,10 @@ def play_file(path, delete_after=False):
     try:
         with open(path, "r") as f:
             for line in f:
+                if stop_playback:
+                    stop_playback = False
+                    log('playback onderbroken')
+                    return
                 if music_len is None and "int musicLen" in line:
                     match = _LEN_PATTERN.search(line)
                     if match:
@@ -294,3 +299,7 @@ def start_playback_async(delay_ms=0):
             log("Async playback fout: {}".format(exc))
 
     _thread.start_new_thread(_runner, ())
+
+def interupt_playback():
+    global stop_playback
+    stop_playback = True

--- a/music_tiles_stepper_edition/lib/esp32_service.dart
+++ b/music_tiles_stepper_edition/lib/esp32_service.dart
@@ -225,6 +225,27 @@ class Esp32Service extends ChangeNotifier {
     }
   }
 
+  Future<void> stopPlayback() async {
+    final String? foundIp = await waitForIp();
+    if (foundIp == null) {
+      return;
+    }
+
+    final HttpClient client = HttpClient();
+    client.connectionTimeout = const Duration(seconds: 3);
+    try {
+      final HttpClientRequest request = await client
+          .getUrl(Uri.parse('http://$foundIp/stop_playback'))
+          .timeout(const Duration(seconds: 4));
+      _setClientHeaders(request);
+      await request.close().timeout(const Duration(seconds: 4));
+    } catch (_) {
+      // Stop playback failed silently
+    } finally {
+      client.close(force: true);
+    }
+  }
+
   void _setClientHeaders(HttpClientRequest request) {
     request.headers.set('X-Client-Type', _clientType);
     request.headers.set('X-Client-Id', _clientId);

--- a/music_tiles_stepper_edition/lib/play.dart
+++ b/music_tiles_stepper_edition/lib/play.dart
@@ -1410,6 +1410,7 @@ class _GamePageState extends State<GamePage> {
     }
 
     _stopAllAudio();
+    _esp32Service.stopPlayback().ignore();
 
     setState(() {
       _gameOver = true;

--- a/music_tiles_stepper_edition/lib/play.dart
+++ b/music_tiles_stepper_edition/lib/play.dart
@@ -1485,7 +1485,10 @@ class _GamePageState extends State<GamePage> {
                       child: Row(
                         children: <Widget>[
                           GestureDetector(
-                            onTap: () => Navigator.of(context).pop(),
+                            onTap: () {
+                              _esp32Service.stopPlayback().ignore();
+                              Navigator.of(context).pop();
+                            },
                             child: Container(
                               width: 40,
                               height: 40,


### PR DESCRIPTION
Expose a /stop_playback HTTP endpoint on the ESP32 and wire a playback interrupt into the music player. Adds a global stop_playback flag and interupt_playback() setter; play_file checks the flag and aborts playback (logging the interruption). The Dart client now has Esp32Service.stopPlayback() to call the endpoint (silent on failure) and the UI calls it before ending a game. This allows the app to remotely stop ongoing audio on the device.